### PR TITLE
refactor(logging): attribute records with contextvars

### DIFF
--- a/heroku/_internal.py
+++ b/heroku/_internal.py
@@ -12,6 +12,10 @@
 
 import asyncio
 import atexit
+import contextlib
+import contextvars
+import functools
+import inspect
 import logging
 import os
 import random
@@ -19,6 +23,78 @@ import signal
 import sys
 import subprocess
 from collections.abc import Callable
+
+
+client_id_ctx: contextvars.ContextVar[int | None] = contextvars.ContextVar(
+    "heroku_client_id",
+    default=None,
+)
+
+
+def get_client_id() -> int | None:
+    """Get id of the client, which owns the current execution context"""
+    return client_id_ctx.get()
+
+
+def set_client_id(client_id: int | None):
+    """Bind the current execution context and its future tasks to the client"""
+    if isinstance(client_id, int):
+        client_id_ctx.set(client_id)
+
+
+def resolve_client_id(instance, path: str) -> int | None:
+    """Read client id from the attribute chain of `instance`"""
+    value = instance
+    for attr in path.split("."):
+        value = getattr(value, attr, None)
+        if value is None:
+            return None
+
+    return value if isinstance(value, int) else None
+
+
+@contextlib.contextmanager
+def client_id_override(client_id: int | None):
+    """Bind the block to the client, detaching it from the outer one if `None`"""
+    token = client_id_ctx.set(client_id)
+    try:
+        yield
+    finally:
+        client_id_ctx.reset(token)
+
+
+@contextlib.contextmanager
+def client_id_scope(client_id: int | None):
+    """Bind the block to the client, keeping the outer one if there is no id"""
+    if not isinstance(client_id, int):
+        yield
+        return
+
+    with client_id_override(client_id):
+        yield
+
+
+def tag_client_id(path: str) -> Callable:
+    """Bind the decorated method to the client, read from `self.<path>`"""
+
+    def decorator(func: Callable) -> Callable:
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(self, *args, **kwargs):
+                with client_id_scope(resolve_client_id(self, path)):
+                    return await func(self, *args, **kwargs)
+
+            return async_wrapper
+
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            with client_id_scope(resolve_client_id(self, path)):
+                return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 async def fw_protect():

--- a/heroku/dispatcher.py
+++ b/heroku/dispatcher.py
@@ -15,7 +15,6 @@
 import asyncio
 import collections
 import contextlib
-import copy
 import inspect
 import logging
 from collections.abc import Callable
@@ -28,6 +27,7 @@ from herokutl.errors import FloodWaitError, RPCError
 from herokutl.tl.types import Message
 
 from . import main, security, utils
+from ._internal import tag_client_id
 from .database import Database
 from .loader import Modules
 from .tl_cache import CustomTelegramClient
@@ -686,6 +686,7 @@ class CommandDispatcher:
                 )
             )
 
+    @tag_client_id("client.tg_id")
     async def future_dispatcher(
         self,
         func: Callable,
@@ -693,9 +694,6 @@ class CommandDispatcher:
         exception_handler: Callable,
         *args,
     ):
-        # Will be used to determine, which client caused logging messages
-        # parsed via inspect.stack()
-        _heroku_client_id_logging_tag = copy.copy(self.client.tg_id)  # noqa: F841
         try:
             await func(message)
         except Exception as e:

--- a/heroku/inline/form.py
+++ b/heroku/inline/form.py
@@ -28,6 +28,7 @@ from herokutl.errors.rpcerrorlist import ChatSendInlineForbiddenError
 from herokutl.tl.types import InputGeoPoint, Message
 
 from .. import main, utils
+from .._internal import tag_client_id
 from ..types import HerokuReplyMarkup
 from .types import InlineMessage, InlineUnit
 
@@ -57,6 +58,7 @@ class Placeholder:
 
 
 class Form(InlineUnit):
+    @tag_client_id("_client.tg_id")
     async def form(
         self: "InlineManager",
         text: str,
@@ -107,9 +109,6 @@ class Form(InlineUnit):
         :param silent: Whether the form must be sent silently (w/o "Opening form..." message)
         :return: If form is sent, returns :obj:`InlineMessage`, otherwise returns `False`
         """
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(self._client.tg_id)  # noqa: F841
-
         if reply_markup is None:
             reply_markup = []
 

--- a/heroku/inline/gallery.py
+++ b/heroku/inline/gallery.py
@@ -12,7 +12,6 @@
 
 import asyncio
 import contextlib
-import copy
 import functools
 import logging
 import os
@@ -27,6 +26,7 @@ from herokutl.errors.rpcerrorlist import ChatSendInlineForbiddenError
 from herokutl.tl.types import Message
 
 from .. import main, utils
+from .._internal import tag_client_id
 from ..types import HerokuReplyMarkup
 from .types import InlineMessage, InlineUnit
 
@@ -50,6 +50,7 @@ class ListGalleryHelper:
 
 
 class Gallery(InlineUnit):
+    @tag_client_id("_client.tg_id")
     async def gallery(
         self: "InlineManager",
         message: Message | int,
@@ -93,9 +94,6 @@ class Gallery(InlineUnit):
         :param silent: Whether the gallery must be sent silently (w/o "Opening gallery..." message)
         :return: If gallery is sent, returns :obj:`InlineMessage`, otherwise returns `False`
         """
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(self._client.tg_id)  # noqa: F841
-
         custom_buttons = self._validate_markup(custom_buttons)
 
         if not (

--- a/heroku/inline/list.py
+++ b/heroku/inline/list.py
@@ -12,7 +12,6 @@
 
 import asyncio
 import contextlib
-import copy
 import functools
 import logging
 import time
@@ -24,6 +23,7 @@ from herokutl.errors.rpcerrorlist import ChatSendInlineForbiddenError
 from herokutl.tl.types import Message
 
 from .. import main, utils
+from .._internal import tag_client_id
 from ..types import HerokuReplyMarkup
 from .types import InlineMessage, InlineUnit
 
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 class List(InlineUnit):
+    @tag_client_id("_client.tg_id")
     async def list(
         self: "InlineManager",
         message: Message | int,
@@ -67,9 +68,6 @@ class List(InlineUnit):
         :param custom_buttons: Custom buttons to add above native ones
         :return: If list is sent, returns :obj:`InlineMessage`, otherwise returns `False`
         """
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(self._client.tg_id)  # noqa: F841
-
         custom_buttons = self._validate_markup(custom_buttons)
 
         if not isinstance(manual_security, bool):

--- a/heroku/loader.py
+++ b/heroku/loader.py
@@ -16,7 +16,6 @@ import asyncio
 import builtins
 import contextlib
 import contextvars
-import copy
 import importlib
 import importlib.machinery
 import importlib.util
@@ -34,6 +33,7 @@ from uuid import uuid4
 from herokutl.tl.tlobject import TLObject
 
 from . import main, security, utils, validators
+from ._internal import resolve_client_id, set_client_id, tag_client_id
 from .database import Database
 from .inline.core import BotUpdateType, InlineManager
 from .translations import Strings, Translator
@@ -212,12 +212,8 @@ class InfiniteLoop:
     def _stop(self, *args, **kwargs):
         self._wait_for_stop.set()
 
+    @tag_client_id("module_instance.allmodules.client.tg_id")
     def stop(self, *args, **kwargs):
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(  # noqa: F841
-                self.module_instance.allmodules.client.tg_id
-            )
-
         if self._task:
             logger.debug("Stopped loop for method %s", self.func)
             self._wait_for_stop = asyncio.Event()
@@ -230,12 +226,8 @@ class InfiniteLoop:
         logger.debug("Loop is not running")
         return asyncio.ensure_future(stop_placeholder())
 
+    @tag_client_id("module_instance.allmodules.client.tg_id")
     def start(self, *args, **kwargs):
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(  # noqa: F841
-                self.module_instance.allmodules.client.tg_id
-            )
-
         if not self._task:
             logger.debug("Started loop for method %s", self.func)
             self._task = asyncio.ensure_future(self.actual_loop(*args, **kwargs))
@@ -246,6 +238,10 @@ class InfiniteLoop:
         # Wait for loader to set attribute
         while not self.module_instance:
             await asyncio.sleep(0.01)
+
+        set_client_id(
+            resolve_client_id(self, "module_instance.allmodules.client.tg_id")
+        )
 
         if isinstance(self._stop_clause, str) and self._stop_clause:
             self.module_instance.set(self._stop_clause, True)
@@ -660,14 +656,12 @@ class Modules:
 
         return loaded
 
+    @tag_client_id("client.tg_id")
     async def _register_modules(
         self,
         modules: list,
         origin: str = "<core>",
     ) -> list[Module]:
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(self.client.tg_id)  # noqa: F841
-
         loaded = []
 
         for mod in modules:
@@ -696,6 +690,7 @@ class Modules:
 
         return loaded
 
+    @tag_client_id("client.tg_id")
     async def register_module(
         self,
         spec: importlib.machinery.ModuleSpec,
@@ -704,9 +699,6 @@ class Modules:
         save_fs: bool = False,
     ) -> Module:
         """Register single module from importlib spec"""
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(self.client.tg_id)  # noqa: F841
-
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
 
@@ -867,11 +859,9 @@ class Modules:
 
         return self._db.get(main.__name__, "remove_core_protection", False)
 
+    @tag_client_id("client.tg_id")
     def register_commands(self, instance: Module):
         """Register commands from instance"""
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(self.client.tg_id)  # noqa: F841
-
         if instance.__origin__.startswith("<core"):
             self._core_commands += list(
                 map(lambda x: x.lower(), list(instance.heroku_commands))
@@ -969,11 +959,9 @@ class Modules:
                     purpose,
                 )
 
+    @tag_client_id("client.tg_id")
     def register_watchers(self, instance: Module):
         """Register watcher from instance"""
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(self.client.tg_id)  # noqa: F841
-
         for _watcher in self.watchers:
             if _watcher.__self__.__class__.__name__ == instance.__class__.__name__:
                 logger.debug("Removing watcher %s for update", _watcher)
@@ -1030,11 +1018,9 @@ class Modules:
 
         return set(prefixes)
 
+    @tag_client_id("client.tg_id")
     async def complete_registration(self, instance: Module):
         """Complete registration of instance"""
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(self.client.tg_id)  # noqa: F841
-
         instance.allmodules = self
         instance.internal_init()
 
@@ -1146,11 +1132,9 @@ class Modules:
         for mod in self.modules:
             self.send_config_one(mod, skip_hook)
 
+    @tag_client_id("client.tg_id")
     def send_config_one(self, mod: Module, skip_hook: bool = False):
         """Send config to single instance"""
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(self.client.tg_id)  # noqa: F841
-
         if hasattr(mod, "config"):
             modcfg = self._db.get(
                 mod.__class__.__name__,
@@ -1207,15 +1191,13 @@ class Modules:
             *[self.send_ready_one_wrapper(mod) for mod in self.modules]
         )
 
+    @tag_client_id("client.tg_id")
     async def send_ready_one(
         self,
         mod: Module,
         no_self_unload: bool = False,
         from_dlmod: bool = False,
     ):
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(self.client.tg_id)  # noqa: F841
-
         if from_dlmod:
             try:
                 if len(inspect.signature(mod.on_dlmod).parameters) == 2:
@@ -1303,12 +1285,10 @@ class Modules:
             name,
         )
 
+    @tag_client_id("client.tg_id")
     async def unload_module(self, classname: str) -> list[str]:
         """Remove module and all stuff from it"""
         worked = []
-
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(self.client.tg_id)  # noqa: F841
 
         for module in self.modules:
             if classname.lower() in (

--- a/heroku/log.py
+++ b/heroku/log.py
@@ -36,6 +36,7 @@ from herokutl.errors.rpcerrorlist import FloodWaitError
 from . import utils
 from ._internal import (
     get_branch_name,
+    get_client_id,
     check_commit_ancestor,
     reset_to_master,
     restore_worktree,
@@ -49,6 +50,10 @@ INTERNET_ERRORS = (
     asyncio.exceptions.TimeoutError,
     ServerError,
     PersistentTimestampOutdatedError,
+)
+COMMON_ERRORS = (
+    "InputPeerEmpty() does not have any entity type",
+    "https://docs.telethon.dev/en/stable/concepts/entities.html",
 )
 old = linecache.getlines
 
@@ -255,6 +260,7 @@ class TelegramLogsHandler(logging.Handler):
         self.force_send_all = False
         self.tg_level = 20
         self.ignore_common = False
+        self._client_options: dict[int, dict] = {}
         self.targets = targets
         self.capacity = capacity
         self.lvl = logging.NOTSET
@@ -276,6 +282,57 @@ class TelegramLogsHandler(logging.Handler):
 
     def setLevel(self, level: int):
         self.lvl = level
+
+    def set_client_options(
+        self,
+        client_id: int,
+        *,
+        force_send_all: bool | None = None,
+        tg_level: int | None = None,
+        ignore_common: bool | None = None,
+    ):
+        """Override logging options for a single client"""
+        options = self._client_options.setdefault(client_id, {})
+
+        for name, value in {
+            "force_send_all": force_send_all,
+            "tg_level": tg_level,
+            "ignore_common": ignore_common,
+        }.items():
+            if value is not None:
+                options[name] = value
+
+    def _option(self, client_id: int, name: str):
+        return self._client_options.get(client_id, {}).get(name, getattr(self, name))
+
+    def _min_tg_level(self) -> int:
+        return min(
+            (self._option(client_id, "tg_level") for client_id in self._mods),
+            default=self.tg_level,
+        )
+
+    def _common_ignored(self) -> bool:
+        if not self._mods:
+            return self.ignore_common
+
+        return all(
+            self._option(client_id, "ignore_common") for client_id in self._mods
+        )
+
+    def _receives(self, client_id: int, item: tuple) -> bool:
+        _, caller, levelno, common = item
+
+        if levelno < self._option(client_id, "tg_level"):
+            return False
+
+        if common and self._option(client_id, "ignore_common"):
+            return False
+
+        return (
+            caller is None
+            or caller == client_id
+            or self._option(client_id, "force_send_all")
+        )
 
     def dump(self):
         """Return a list of logging entries"""
@@ -349,11 +406,7 @@ class TelegramLogsHandler(logging.Handler):
                                 item[0]
                                 for item in self.tg_buff
                                 if isinstance(item[0], str)
-                                and (
-                                    not item[1]
-                                    or item[1] == client_id
-                                    or self.force_send_all
-                                )
+                                and self._receives(client_id, item)
                             ]
                         )
                     ),
@@ -370,7 +423,7 @@ class TelegramLogsHandler(logging.Handler):
                 for item in self.tg_buff:
                     if not isinstance(item[0], HerokuException):
                         continue
-                    if not (not item[1] or item[1] == client_id or self.force_send_all):
+                    if not self._receives(client_id, item):
                         continue
                     if isinstance(item[0].sysinfo[1], INTERNET_ERRORS) and getattr(
                         self._mods[client_id].lookup("tester"), "config", {}
@@ -473,30 +526,31 @@ class TelegramLogsHandler(logging.Handler):
                     exc_info=True,
                 )
 
+    @staticmethod
+    def _legacy_caller() -> int | None:
+        frame = sys._getframe(1)
+
+        while frame:
+            tag = frame.f_locals.get("_heroku_client_id_logging_tag")
+            if isinstance(tag, int):
+                return tag
+
+            frame = frame.f_back
+
+        return None
+
     def emit(self, record: logging.LogRecord):
         try:
-            caller = next(
-                (
-                    frame_info.frame.f_locals["_heroku_client_id_logging_tag"]
-                    for frame_info in inspect.stack()
-                    if isinstance(
-                        getattr(getattr(frame_info, "frame", None), "f_locals", {}).get(
-                            "_heroku_client_id_logging_tag"
-                        ),
-                        int,
-                    )
-                ),
-                False,
-            )
+            caller = get_client_id()
 
-            if not isinstance(caller, int):
-                caller = None
+            if caller is None:
+                caller = self._legacy_caller()
         except Exception:
             caller = None
 
         record.heroku_caller = caller
 
-        if record.levelno >= self.tg_level:
+        if record.levelno >= self._min_tg_level():
             if record.exc_info:
                 try:
                     if record.args:
@@ -512,19 +566,17 @@ class TelegramLogsHandler(logging.Handler):
                     comment=comment,
                 )
 
-                if not self.ignore_common or all(
-                    field not in exc.message
-                    for field in [
-                        "InputPeerEmpty() does not have any entity type",
-                        "https://docs.telethon.dev/en/stable/concepts/entities.html",
-                    ]
-                ):
-                    self.tg_buff += [(exc, caller)]
+                common = any(field in exc.message for field in COMMON_ERRORS)
+
+                if not common or not self._common_ignored():
+                    self.tg_buff += [(exc, caller, record.levelno, common)]
             else:
                 self.tg_buff += [
                     (
                         _tg_formatter.format(record),
                         caller,
+                        record.levelno,
+                        False,
                     )
                 ]
 

--- a/heroku/main.py
+++ b/heroku/main.py
@@ -17,6 +17,7 @@ import asyncio
 import base64
 import binascii
 import collections
+import contextlib
 import importlib
 import json
 import logging
@@ -27,6 +28,7 @@ import signal
 import sqlite3
 import string
 import sys
+import traceback
 import typing
 import zlib
 from getpass import getpass
@@ -57,7 +59,13 @@ from herokutl.tl.functions.auth import CheckPasswordRequest
 from herokutl.tl.functions.contacts import UnblockRequest
 
 from . import database, loader, utils, version
-from ._internal import print_banner, restart
+from ._internal import (
+    client_id_ctx,
+    client_id_override,
+    print_banner,
+    restart,
+    set_client_id,
+)
 from .dispatcher import CommandDispatcher
 from .qr import QRCode
 from .secure import patcher
@@ -979,6 +987,7 @@ class Heroku:
             client.tg_id = me.id
             client.hikka_me = me
             client.heroku_me = me
+            set_client_id(me.id)
 
             await version.check_branch(me.id, a_i, self)
 
@@ -1130,6 +1139,34 @@ class Heroku:
 
         await client.run_until_disconnected()
 
+    @staticmethod
+    def _loop_exception_handler(_, context: dict):
+        """Log an error, caught by the event loop, with the task, which caused it"""
+        culprit = (
+            context.get("task") or context.get("future") or context.get("handle")
+        )
+        details = f" [{culprit!r}]" if culprit is not None else ""
+        source = context.get("source_traceback")
+
+        if source:
+            details += "\nTask was created at:\n" + "".join(
+                traceback.format_list(source[-5:])
+            ).rstrip()
+
+        owner = None
+
+        if hasattr(culprit, "get_context"):
+            with contextlib.suppress(Exception):
+                owner = culprit.get_context().get(client_id_ctx)
+
+        with client_id_override(owner):
+            logging.error(
+                "Exception on event loop! %s%s",
+                context.get("message", "unknown error"),
+                details,
+                exc_info=context.get("exception"),
+            )
+
     async def _main(self):
         """Main entrypoint"""
         _s = "485633554d534b53475a4c454336444b4e5a43474357424c4b4e5957495a43494b5a5558555a52514e4a4744435a4c43475649464d5753484b524b5649525a554a465a45555332584e493246453332574e5a58544d325a4c4734344553534c514f4a4358473332514d5252574f5642574e4242484b595a5a47524d544f34535a4d464655533333424a4e4e47324e33594d55595649524c45494a4755435133584a4e43554b364b574f3546474b3d3d3d"
@@ -1140,13 +1177,7 @@ class Heroku:
         ) and not await self._initial_setup():
             return
 
-        self.loop.set_exception_handler(
-            lambda _, x: logging.error(
-                "Exception on event loop! %s",
-                x["message"],
-                exc_info=x.get("exception", None),
-            )
-        )
+        self.loop.set_exception_handler(self._loop_exception_handler)
 
         try:
             d5 = binascii.unhexlify(_s)

--- a/heroku/modules/test.py
+++ b/heroku/modules/test.py
@@ -56,8 +56,8 @@ class TestMod(loader.Module):
                     " is a module TestModule installed on Client1 and TestModule2 on"
                     " Client2. By default, Client2 will get logs from TestModule2, and"
                     " Client1 will get logs from TestModule. If this option is enabled,"
-                    " Heroku will send all logs to Client1 and Client2, even if it is"
-                    " not the one that caused the log."
+                    " this client will also receive logs, caused by other clients. It"
+                    " affects this client only."
                 ),
                 validator=loader.validators.Boolean(),
                 on_change=self._pass_config_to_logger,
@@ -136,24 +136,32 @@ class TestMod(loader.Module):
         )
 
     def _pass_config_to_logger(self):
-        logging.getLogger().handlers[0].force_send_all = self.config["force_send_all"]
-        logging.getLogger().handlers[0].tg_level = {
-            "ALL": 0,
-            "DEBUG": 10,
-            "INFO": 20,
-            "WARNING": 30,
-            "ERROR": 40,
-            "CRITICAL": 50,
-            "DISABLE": 50000,
-        }[self.config["tglog_level"]]
-        logging.getLogger().handlers[0].ignore_common = self.config["ignore_common"]
+        client_id = getattr(self, "tg_id", None)
+
+        if client_id is None:
+            return
+
+        logging.getLogger().handlers[0].set_client_options(
+            client_id,
+            force_send_all=self.config["force_send_all"],
+            tg_level={
+                "ALL": 0,
+                "DEBUG": 10,
+                "INFO": 20,
+                "WARNING": 30,
+                "ERROR": 40,
+                "CRITICAL": 50,
+                "DISABLE": 50000,
+            }[self.config["tglog_level"]],
+            ignore_common=self.config["ignore_common"],
+        )
 
     @loader.command()
     async def clearlogs(self, message: Message):
         for handler in logging.getLogger().handlers:
             handler.buffer = []
             handler.handledbuffer = []
-            handler.tg_buff = ""
+            handler.tg_buff = []
 
         await utils.answer(message, self.strings["logs_cleared"])
 

--- a/heroku/tl_cache.py
+++ b/heroku/tl_cache.py
@@ -39,6 +39,7 @@ from herokutl.tl.types import (
 )
 from herokutl.utils import is_list_like
 
+from ._internal import tag_client_id
 from .types import (
     CacheRecordEntity,
     CacheRecordFullChannel,
@@ -239,6 +240,7 @@ class CustomTelegramClient(TelegramClient):
 
         return await self.get_entity(*args, force=True, **kwargs)
 
+    @tag_client_id("tg_id")
     async def get_entity(
         self,
         entity: EntityLike,
@@ -253,10 +255,6 @@ class CustomTelegramClient(TelegramClient):
         :param force: Whether to force refresh the cache (make API request)
         :return: :obj:`Entity`
         """
-
-        # Will be used to determine, which client caused logging messages
-        # parsed via inspect.stack()
-        _heroku_client_id_logging_tag = copy.copy(self.tg_id)  # noqa: F841
 
         if not hashable(entity):
             try:
@@ -314,6 +312,7 @@ class CustomTelegramClient(TelegramClient):
 
         return copy.deepcopy(resolved_entity)
 
+    @tag_client_id("tg_id")
     async def get_perms_cached(
         self,
         entity: EntityLike,
@@ -330,10 +329,6 @@ class CustomTelegramClient(TelegramClient):
         :param force: Whether to force refresh the cache (make API request)
         :return: :obj:`ChatPermissions`
         """
-
-        # Will be used to determine, which client caused logging messages
-        # parsed via inspect.stack()
-        _heroku_client_id_logging_tag = copy.copy(self.tg_id)  # noqa: F841
 
         entity = await self.get_entity(entity)
         user = await self.get_entity(user) if user else None

--- a/heroku/types.py
+++ b/heroku/types.py
@@ -42,6 +42,7 @@ from herokutl.tl.types import (
 )
 
 from . import version
+from ._internal import tag_client_id
 from ._reference_finder import replace_all_refs
 from .inline.types import (
     BotInlineCall,
@@ -258,6 +259,7 @@ class Module:
     def heroku_watchers(self, _):
         pass
 
+    @tag_client_id("client.tg_id")
     async def animate(
         self,
         message: Message | InlineMessage,
@@ -278,9 +280,6 @@ class Module:
         button due to the limitations of Telegram API
         """
         from . import utils
-
-        with contextlib.suppress(AttributeError):
-            _heroku_client_id_logging_tag = copy.copy(self.client.tg_id)  # noqa: F841
 
         if interval < 0.1:
             logger.warning(


### PR DESCRIPTION
Client attribution no longer depends primarily on inspect.stack(). Add client_id ContextVar, tag_client_id decorator, client_id_scope, and client_id_override helpers.

- Bind the context in amain_wrapper and InfiniteLoop.actual_loop so the entire task tree inherits the owning client ID. Replace manual tags across dispatcher, loader, tl_cache, types, and inline units.

- Keep stack scanning as a fallback for third-party modules, but walk f_back instead of constructing inspect.stack().

- Make force_send_all, tg_level, and ignore_common configurable per client. Store levelno and the common-error flag in tg_buff records so filtering occurs at send time.

- In debug mode, log the task and source_traceback for event-loop errors and attribute them to the task owner.

- Fix clearlogs resetting tg_buff to a string, which caused TypeError on the next log record.