### PR TITLE
fix tasks disappearing mid-execution via asyncio.ensure_future/create_task

### DIFF
--- a/heroku/_internal.py
+++ b/heroku/_internal.py
@@ -99,6 +99,37 @@ def tag_client_id(path: str) -> Callable:
 
     return decorator
 
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _track_task(task: asyncio.Task) -> asyncio.Task:
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
+
+
+def install_task_tracking():
+    if getattr(asyncio.ensure_future, "_heroku_tracked", False):
+        return
+
+    original_ensure_future = asyncio.ensure_future
+    original_create_task = asyncio.create_task
+
+    def ensure_future(coro_or_future, **kwargs):
+        result = original_ensure_future(coro_or_future, **kwargs)
+        if isinstance(result, asyncio.Task):
+            _track_task(result)
+        return result
+
+    def create_task(coro, **kwargs):
+        return _track_task(original_create_task(coro, **kwargs))
+
+    ensure_future._heroku_tracked = True
+    create_task._heroku_tracked = True
+
+    asyncio.ensure_future = ensure_future
+    asyncio.create_task = create_task
+
 
 async def fw_protect():
     await asyncio.sleep(random.randint(1000, 2000) / 1000)

--- a/heroku/_internal.py
+++ b/heroku/_internal.py
@@ -109,27 +109,17 @@ def _track_task(task: asyncio.Task) -> asyncio.Task:
 
 
 def install_task_tracking():
-    if getattr(asyncio.ensure_future, "_heroku_tracked", False):
+    loop_cls = asyncio.base_events.BaseEventLoop
+    if getattr(loop_cls.create_task, "_heroku_tracked", False):
         return
 
-    original_ensure_future = asyncio.ensure_future
-    original_create_task = asyncio.create_task
+    original_create_task = loop_cls.create_task
 
-    def ensure_future(coro_or_future, **kwargs):
-        result = original_ensure_future(coro_or_future, **kwargs)
-        if isinstance(result, asyncio.Task):
-            _track_task(result)
-        return result
+    def create_task(self, coro, **kwargs):
+        return _track_task(original_create_task(self, coro, **kwargs))
 
-    def create_task(coro, **kwargs):
-        return _track_task(original_create_task(coro, **kwargs))
-
-    ensure_future._heroku_tracked = True
     create_task._heroku_tracked = True
-
-    asyncio.ensure_future = ensure_future
-    asyncio.create_task = create_task
-
+    loop_cls.create_task = create_task
 
 async def fw_protect():
     await asyncio.sleep(random.randint(1000, 2000) / 1000)

--- a/heroku/main.py
+++ b/heroku/main.py
@@ -62,6 +62,7 @@ from . import database, loader, utils, version
 from ._internal import (
     client_id_ctx,
     client_id_override,
+    install_task_tracking,
     print_banner,
     restart,
     set_client_id,
@@ -514,6 +515,8 @@ class Heroku:
         except RuntimeError:
             self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)
+
+        install_task_tracking()
 
         self.clients = SuperList()
         self.ready = asyncio.Event()


### PR DESCRIPTION
**Problem**
Across the codebase (and in herokutl itself - e.g. `events/album.py`, `events/callbackquery.py`) results of `asyncio.ensure_future()`/`create_task()`/`loop.create_task()` were routinely discarded without keeping a reference. Per the asyncio docs, a Task referenced nowhere else is only weakly held by the event loop and can be garbage-collected mid-execution.

**Fix**
Patches BaseEventLoop.create_task at the class level. Patching at that single choke point transparently covers everything: Heroku code, and any third-party/downloaded module, including ones that call `some_loop.create_task(...)` directly.

Every spawned task is kept in a set until its add_done_callback fires, so it stays strongly referenced for its full lifetime. Installed once at startup, safe to call again.